### PR TITLE
feat(xchain-arb): demo xchain arb using xchain flash loan

### DIFF
--- a/src/mocks/ExchangeMock.sol
+++ b/src/mocks/ExchangeMock.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.19;
+
+import {IERC20} from "../interfaces/IERC20.sol";
+import {SafeTransferLib} from "../libraries/SafeTransferLib.sol";
+
+contract ExchangeMock {
+    using SafeTransferLib for IERC20;
+
+    // Exchange rate in basis points (1 basis point = 0.01%)
+    // 10000 = 1:1 exchange rate
+    uint256 public exchangeRate;
+    IERC20 public immutable token0;
+    IERC20 public immutable token1;
+
+    constructor(address _token0, address _token1, uint256 _exchangeRate) {
+        token0 = IERC20(_token0);
+        token1 = IERC20(_token1);
+        exchangeRate = _exchangeRate;
+    }
+
+    function setExchangeRate(uint256 _exchangeRate) external {
+        exchangeRate = _exchangeRate;
+    }
+
+    // Swap token0 for token1
+    function swapToken0ForToken1(uint256 amountIn) external returns (uint256 amountOut) {
+        amountOut = (amountIn * exchangeRate) / 10000;
+        token0.safeTransferFrom(msg.sender, address(this), amountIn);
+        token1.safeTransfer(msg.sender, amountOut);
+    }
+
+    // Swap token1 for token0
+    function swapToken1ForToken0(uint256 amountIn) external returns (uint256 amountOut) {
+        amountOut = (amountIn * 10000) / exchangeRate;
+        token1.safeTransferFrom(msg.sender, address(this), amountIn);
+        token0.safeTransfer(msg.sender, amountOut);
+    }
+}

--- a/src/mocks/FlashXChainBorrowerMock.sol
+++ b/src/mocks/FlashXChainBorrowerMock.sol
@@ -19,16 +19,16 @@ contract FlashXChainBorrowerMock is IMorphoFlashLoanCallback {
 
     function onMorphoFlashLoan(uint256 assets, bytes calldata data) external {
         // Decode the exchange addresses and token from the callback data
-        (address sourceExchange, address destExchange, address token0, address token1) =
+        (address exchange1Addr, address exchange2Addr, address token0, address token1) =
             abi.decode(data, (address, address, address, address));
 
         // Get exchange contracts
-        ExchangeMock exchange1 = ExchangeMock(sourceExchange);
-        ExchangeMock exchange2 = ExchangeMock(destExchange);
+        ExchangeMock exchange1 = ExchangeMock(exchange1Addr);
+        ExchangeMock exchange2 = ExchangeMock(exchange2Addr);
 
         // // Approve exchanges to spend our tokens
-        IERC20(token0).approve(sourceExchange, assets);
-        IERC20(token1).approve(destExchange, type(uint256).max);
+        IERC20(token0).approve(exchange1Addr, assets);
+        IERC20(token1).approve(exchange2Addr, type(uint256).max);
 
         // Perform arbitrage:
         // 1. Swap token0 for token1 on first exchange

--- a/src/mocks/FlashXChainBorrowerMock.sol
+++ b/src/mocks/FlashXChainBorrowerMock.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import {IERC20} from "./interfaces/IERC20.sol";
 import {IMorpho} from "../interfaces/IMorpho.sol";
 import {IMorphoFlashLoanCallback} from "../interfaces/IMorphoCallbacks.sol";
+import {ExchangeMock} from "./ExchangeMock.sol";
 
 contract FlashXChainBorrowerMock is IMorphoFlashLoanCallback {
     IMorpho private immutable MORPHO;
@@ -17,8 +18,29 @@ contract FlashXChainBorrowerMock is IMorphoFlashLoanCallback {
     }
 
     function onMorphoFlashLoan(uint256 assets, bytes calldata data) external {
-        require(msg.sender == address(MORPHO));
-        address token = abi.decode(data, (address));
-        IERC20(token).approve(address(MORPHO), assets);
+        // Decode the exchange addresses and token from the callback data
+        (address sourceExchange, address destExchange, address token0, address token1) =
+            abi.decode(data, (address, address, address, address));
+
+        // Get exchange contracts
+        ExchangeMock exchange1 = ExchangeMock(sourceExchange);
+        ExchangeMock exchange2 = ExchangeMock(destExchange);
+
+        // // Approve exchanges to spend our tokens
+        IERC20(token0).approve(sourceExchange, assets);
+        IERC20(token1).approve(destExchange, type(uint256).max);
+
+        // Perform arbitrage:
+        // 1. Swap token0 for token1 on first exchange
+        uint256 token1Amount = exchange1.swapToken0ForToken1(assets);
+
+        // // 2. Swap token1 back to token0 on second exchange
+        exchange2.swapToken1ForToken0(token1Amount);
+
+        // Ensure we made a profit
+        require(IERC20(token0).balanceOf(address(this)) > assets, "No profit made");
+
+        // Approve Morpho to take back the flash loaned amount
+        IERC20(token0).approve(msg.sender, assets);
     }
 }

--- a/src/mocks/XChainERC20Mock.sol
+++ b/src/mocks/XChainERC20Mock.sol
@@ -4,19 +4,25 @@ pragma solidity ^0.8.25;
 import {SuperchainERC20} from "./SuperchainERC20.sol";
 
 contract XChainERC20Mock is SuperchainERC20 {
-    string private constant _name = "XChainFlashLoan";
-    string private constant _symbol = "CXL";
-    uint8 private constant _decimals = 18;
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
 
-    function name() public pure override returns (string memory) {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+    }
+
+    function name() public view override returns (string memory) {
         return _name;
     }
 
-    function symbol() public pure override returns (string memory) {
+    function symbol() public view override returns (string memory) {
         return _symbol;
     }
 
-    function decimals() public pure override returns (uint8) {
+    function decimals() public view override returns (uint8) {
         return _decimals;
     }
 

--- a/test/interop/morpho.test.ts
+++ b/test/interop/morpho.test.ts
@@ -3,9 +3,9 @@ import { SuperContract, SuperWallet as Wallet, getSuperContract } from 'supercha
 import { ethers } from 'ethers'
 import { config } from './config'
 import { MORPHO_ABI, MORPHO_BYTECODE } from './contracts'
-import ERC20MockArtifact from '../../out/ERC20Mock.sol/ERC20Mock.json'
 import XChainERC20MockArtifact from '../../out/XChainERC20Mock.sol/XChainERC20Mock.json'
 import FlashXChainBorrowerMockArtifact from '../../out/FlashXChainBorrowerMock.sol/FlashXChainBorrowerMock.json'
+import ExchangeMockArtifact from '../../out/ExchangeMock.sol/ExchangeMock.json'
 import IrmMockArtifact from '../../out/IrmMock.sol/IrmMock.json'
 const toHexString = (char: string, length: number = 40): `0x${string}` => 
     `0x${char.repeat(length)}` as `0x${string}`
@@ -15,8 +15,10 @@ describe('Morpho Interop Tests', () => {
     const PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const
     const wallet = new Wallet(PRIVATE_KEY)
     let morpho: SuperContract
-    let token: SuperContract
-    let xChainToken: SuperContract
+    let token0: SuperContract
+    let token1: SuperContract
+    let exchange1: SuperContract
+    let exchange2: SuperContract
     let flashBorrower: SuperContract
     let irm: SuperContract
     let walletAddress: string
@@ -34,24 +36,23 @@ describe('Morpho Interop Tests', () => {
             wallet,
             MORPHO_ABI,
             MORPHO_BYTECODE,
-            [walletAddress] // Pass wallet address as newOwner
+            [walletAddress]
         )
 
-
-        token = getSuperContract(
-            config,
-            wallet,
-            ERC20MockArtifact.abi,
-            ERC20MockArtifact.bytecode.object as `0x${string}`,
-            []
-        )
-
-        xChainToken = getSuperContract(
+        token0 = getSuperContract(
             config,
             wallet,
             XChainERC20MockArtifact.abi,
             XChainERC20MockArtifact.bytecode.object as `0x${string}`,
-            []
+            ["XChainToken0", "X0", 18]
+        )
+
+        token1 = getSuperContract(
+            config,
+            wallet,
+            XChainERC20MockArtifact.abi,
+            XChainERC20MockArtifact.bytecode.object as `0x${string}`,
+            ["XChainToken1", "X1", 18]
         )
 
         irm = getSuperContract(
@@ -62,15 +63,37 @@ describe('Morpho Interop Tests', () => {
             []
         )
 
-        // Deploy Morpho first since we need its address for FlashBorrower
+        // Deploy base contracts
         await morpho.deploy(901)
         await morpho.deploy(902)
-        await token.deploy(901)
-        await xChainToken.deploy(901)
-        await xChainToken.deploy(902)
+        await token0.deploy(901)
+        await token0.deploy(902)
+        await token1.deploy(901)
+        await token1.deploy(902)
         await irm.deploy(901)
         await irm.deploy(902)
 
+        // Create and deploy exchanges with different rates
+        exchange1 = getSuperContract(
+            config,
+            wallet,
+            ExchangeMockArtifact.abi,
+            ExchangeMockArtifact.bytecode.object as `0x${string}`,
+            [token0.address, token1.address, 10000] // 1:1 rate
+        )
+
+        exchange2 = getSuperContract(
+            config,
+            wallet,
+            ExchangeMockArtifact.abi,
+            ExchangeMockArtifact.bytecode.object as `0x${string}`,
+            [token0.address, token1.address, 9000] // .9:1 rate
+        )
+
+        await exchange1.deploy(902)
+        await exchange2.deploy(902)
+
+        // Deploy flash borrower
         flashBorrower = getSuperContract(
             config,
             wallet,
@@ -81,14 +104,23 @@ describe('Morpho Interop Tests', () => {
         await flashBorrower.deploy(901)
         await flashBorrower.deploy(902)
 
+        // Setup exchange liquidity
+        const INITIAL_LIQUIDITY = ethers.parseEther('1000')
+        
+        // Mint and approve tokens for exchanges
+        await token0.sendTx(902, 'mint', [exchange1.address, INITIAL_LIQUIDITY])
+        await token1.sendTx(902, 'mint', [exchange1.address, INITIAL_LIQUIDITY])
+        await token0.sendTx(902, 'mint', [exchange2.address, INITIAL_LIQUIDITY])
+        await token1.sendTx(902, 'mint', [exchange2.address, INITIAL_LIQUIDITY])
+
         // Enable IRM and LLTV for market creation
         await morpho.sendTx(901, 'enableIrm', [irm.address])
         await morpho.sendTx(901, 'enableLltv', [ethers.parseEther('0.8')])
 
         // Create market params
         const marketParams = {
-            loanToken: token.address,
-            collateralToken: token.address, // Using same token as collateral
+            loanToken: token0.address,
+            collateralToken: token0.address,
             oracle: mockOracle,
             irm: irm.address,
             lltv: ethers.parseEther('0.8')
@@ -98,33 +130,53 @@ describe('Morpho Interop Tests', () => {
         await morpho.sendTx(901, 'createMarket', [marketParams])
     }, 60000)
 
-    it('should supply tokens and do a xchain flash loan', async () => {
-        // Mint tokens for the bridge on chain 901
-        const amount = 1000n
-        await xChainToken.sendTx(901, 'mint', [morpho.address, amount])
-        const bridgePreBalance = await xChainToken.call(901, 'balanceOf', [morpho.address])
-        expect(bridgePreBalance).toBe(amount)
-        const flashXChainBorrowerPreBalance = await xChainToken.call(901, 'balanceOf', [flashBorrower.address])
-        expect(flashXChainBorrowerPreBalance).toBe(0n)
+    it('should perform cross-chain arbitrage using flash loan', async () => {
+        const FLASH_LOAN_AMOUNT = ethers.parseEther('100')
+        
+        // Mint tokens for Morpho to enable flash loans
+        await token0.sendTx(901, 'mint', [morpho.address, FLASH_LOAN_AMOUNT])
+        const morphoInitialBalance = await token0.call(901, 'balanceOf', [morpho.address])
+        
+        // Get initial balances
+        const borrowerInitialBalance = await token0.call(902, 'balanceOf', [flashBorrower.address])
+        expect(borrowerInitialBalance).toBe(0n)
 
+        // Encode flash loan data with exchange addresses and tokens
         const abiCoder = new ethers.AbiCoder()
-        const flashLoanData = abiCoder.encode(['address'], [xChainToken.address])
-        const FEE = 10000000000000000n 
-        await flashBorrower.sendTx(901, 'flashLoan', [xChainToken.address, 902n, amount, flashLoanData], FEE)
+        const flashLoanData = abiCoder.encode(
+            ['address', 'address', 'address', 'address'],
+            [exchange1.address, exchange2.address, token0.address, token1.address]
+        )
 
+        // Execute flash loan with arbitrage
+        const FEE = ethers.parseEther('0.0001')
+        await flashBorrower.sendTx(
+            901,
+            'flashLoan',
+            [token0.address, 902n, FLASH_LOAN_AMOUNT, flashLoanData],
+            FEE
+        )
+
+        // Wait for the cross-chain transaction to complete
         await waitForTrue(async () => {
-            const bridgePostBalance = await xChainToken.call(901, 'balanceOf', [morpho.address])
-            const flashXChainBorrowerPostBalance = await xChainToken.call(901, 'balanceOf', [flashBorrower.address])
-            return bridgePostBalance === amount && flashXChainBorrowerPostBalance === 0n
-        }, 30000, 1000, 'Bridge balance did not update to expected value')
-    }, 60000)
+            const borrowerFinalBalance = await token0.call(902, 'balanceOf', [flashBorrower.address])
+            // Should have made a profit
+            return borrowerFinalBalance > borrowerInitialBalance
+        }, 30000, 1000, 'Arbitrage did not complete successfully')
 
-    // TODO: Add more tests for basic interactions
-    // - Market creation
-    // - Supply
-    // - Borrow
-    // etc.
-}) 
+        // Verify borrower made a profit off arbitrage
+        const borrowerFinalBalance = await token0.call(902, 'balanceOf', [flashBorrower.address])
+        console.log('Profit made:', ethers.formatEther(borrowerFinalBalance))
+        expect(borrowerFinalBalance).toBeGreaterThan(0n)
+
+        // Wait for cross-chain transaction of sending tokens back to Morpho on source chain
+        await waitForTrue(async () => {
+            // Verify Morpho's balance is unchanged
+            const morphoFinalBalance = await token0.call(901, 'balanceOf', [morpho.address])
+            return morphoFinalBalance === morphoInitialBalance
+        }, 30000, 1000, 'Morpho\'s balance is not unchanged')
+    }, 60000)
+})
 
 async function waitForTrue(
     callback: () => Promise<boolean>,


### PR DESCRIPTION
# Cross-Chain Flash Loan Arbitrage Test

Adds a test that demonstrates cross-chain flash loan functionality. In this scenario:

1. A cross-chain flash loan is initiated from Morpho on chain 901
2. The borrowed tokens on chain 901 are used to execute arbitrage between two exchanges on chain 902
3. The test verifies that:
   - The borrower successfully makes a profit from the arbitrage
   - Morpho's token balance on chain 901 remains unchanged after the flash loan completes

This demonstrates the full cycle of cross-chain flash loans, from initiation through arbitrage execution and final repayment.

```mermaid
sequenceDiagram
    participant Borrower
    participant Morpho901 as Morpho (Chain 901)
    participant Bridge
    participant Exchange1_902 as Exchange1 (Chain 902)
    participant Exchange2_902 as Exchange2 (Chain 902)
    participant Morpho902 as Morpho (Chain 902)

    Borrower->>Morpho901: 1. initiateCrosschainFlashLoan()
    Morpho901->>Bridge: 2. Bridge tokens to Chain 902
    Bridge->>Morpho902: 3. Tokens arrive on Chain 902
    Morpho902->>Borrower: 4. Flash loan callback with tokens
    Borrower->>Exchange1_902: 5. Swap token0 for token1
    Borrower->>Exchange2_902: 6. Swap token1 for token0 (profit)
    Borrower->>Morpho902: 7. Return flash loaned tokens
    Morpho902->>Bridge: 8. Bridge tokens back to Chain 901
    Bridge->>Morpho901: 9. Tokens returned to original chain
    Note over Borrower: Keeps arbitrage profit
```